### PR TITLE
Bump bindgen version

### DIFF
--- a/lttng-ust-generate/Cargo.toml
+++ b/lttng-ust-generate/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT"
 repository = "https://github.com/bobtwinkles/lttng-ust-rs/"
 
 [dependencies]
-bindgen = "0.32.3"
+bindgen = "0.51"
 cc = "1.0"

--- a/lttng-ust-generate/src/generator/rust_bindings.rs
+++ b/lttng-ust-generate/src/generator/rust_bindings.rs
@@ -101,6 +101,8 @@ fn c_arg_for_field(base_name: String, field: &Field) -> String {
         format!("::std::mem::transmute({0}.as_bytes().as_ptr()), {0}.len()", base_name)
     } else if field.ctf_type.is_sequence() {
         base_name.clone() + ", " + &base_name + ".len()"
+    } else if let CTFType::Array(_, _) | CTFType::ArrayNoWrite(_, _) = field.ctf_type {
+        format!("{}.as_ptr()", base_name)
     } else {
         base_name
     }

--- a/lttng-ust-generate/src/lib.rs
+++ b/lttng-ust-generate/src/lib.rs
@@ -274,14 +274,14 @@ impl CIntegerType {
     /// String version of the C type this represents as a pointer
     fn c_pointer_type(&self) -> &'static str {
         match *self {
-            CIntegerType::I8 =>   "int8_t *",
-            CIntegerType::U8 =>  "uint8_t *",
-            CIntegerType::I16 =>  "int16_t *",
-            CIntegerType::U16 => "uint16_t *",
-            CIntegerType::I32 =>  "int32_t *",
-            CIntegerType::U32 => "uint32_t *",
-            CIntegerType::I64 =>  "int64_t *",
-            CIntegerType::U64 => "uint64_t *"
+            CIntegerType::I8 =>   "const int8_t *",
+            CIntegerType::U8 =>  "const uint8_t *",
+            CIntegerType::I16 =>  "const int16_t *",
+            CIntegerType::U16 => "const uint16_t *",
+            CIntegerType::I32 =>  "const int32_t *",
+            CIntegerType::U32 => "const uint32_t *",
+            CIntegerType::I64 =>  "const int64_t *",
+            CIntegerType::U64 => "const uint64_t *"
         }
     }
 


### PR DESCRIPTION
Due to https://github.com/rust-lang/cargo/issues/5237 I have a conflict between versions of bindgen used in different crate's build scripts. In order to work around this for the time being, I have increased the version of bindgen used in lttng-ust-generate. No code changes are required. Just a dependency version change.