### PR TITLE
Fix: Compilation error when using CTFType::String{,NoWrite}

### DIFF
--- a/lttng-ust-generate/src/generator/rust_bindings.rs
+++ b/lttng-ust-generate/src/generator/rust_bindings.rs
@@ -78,7 +78,7 @@ fn rust_type_for(ty: &CTFType) -> String {
         FloatNoWrite(f) => f.rust_type().into(),
 
         String |
-        StringNoWrite => "::std::ffi::CStr".into(),
+        StringNoWrite => "& ::std::ffi::CStr".into(),
 
         Array(i, l) |
         ArrayNoWrite(i, l) => format!("&[{}; {}]", i.rust_type(), l),
@@ -101,7 +101,7 @@ fn c_arg_for_field(base_name: String, field: &Field) -> String {
         format!("::std::mem::transmute({0}.as_bytes().as_ptr()), {0}.len()", base_name)
     } else if field.ctf_type.is_sequence() {
         base_name.clone() + ", " + &base_name + ".len()"
-    } else if let CTFType::Array(_, _) | CTFType::ArrayNoWrite(_, _) = field.ctf_type {
+    } else if let CTFType::Array(_, _) | CTFType::ArrayNoWrite(_, _) | CTFType::String | CTFType::StringNoWrite = field.ctf_type {
         format!("{}.as_ptr()", base_name)
     } else {
         base_name


### PR DESCRIPTION
Previously the rust type was `std::ffi::CStr` which is similar to `str` and does not have known size at compile-time and cannot be used as a function argument. Use reference `&CStr` instead.

# Tracepoint definition

```rust
provider
        .create_class("class")
        .add_field("c_string", CTFType::String)
        .instantiate("tracepoint");
```

# The compile error
```
   Compiling lttng-test v0.1.0
error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
   --> REDACTED/out/tracepoints.rs:8:46
    |
8   |         pub(in super::super) fn tracepoint<>(a0: ::std::ffi::CStr) {
    |                                              ^^ doesn't have a size known at compile-time
    |
    = help: within `CStr`, the trait `Sized` is not implemented for `[i8]`, which is required by `CStr: Sized`
note: required because it appears within the type `CStr`
   --> HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ffi/c_str.rs:108:12
    |
108 | pub struct CStr {
    |            ^^^^
help: function arguments must have a statically known size, borrowed types always have a known size
    |
8   |         pub(in super::super) fn tracepoint<>(a0: &::std::ffi::CStr) {
    |                                                  +

error[E0308]: mismatched types
  --> REDACTED/out/tracepoints.rs:10:61
   |
10 |                 super::detail::provider_class_tracepoint_tp(a0)
   |                 ------------------------------------------- ^^ expected `*const i8`, found `CStr`
   |                 |
   |                 arguments to this function are incorrect
   |
   = note: expected raw pointer `*const i8`
                   found struct `CStr`
note: function defined here
  --> REDACTED/out/lttng-tracepoints/tracepoint_library_link_name/tracepoints.rs:4:12
   |
4  |     pub fn provider_class_tracepoint_tp(c_string_arg: *const ::std::os::raw::c_char);
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `lttng-test` (bin "lttng-test") due to 2 previous errors
```